### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/manifoldco/promptui
+module github.com/nguyer/promptui
 
 go 1.12
 


### PR DESCRIPTION
Fix this error:

```
go: github.com/nguyer/promptui@v0.8.1-0.20210517132806-70ccd4709797: parsing go.mod:
	module declares its path as: github.com/manifoldco/promptui
	        but was required as: github.com/nguyer/promptui
```